### PR TITLE
remove duplicate docker steps, add pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ MIT's Global Entrepreneurship Bootcamp issued digital certificates to the studen
 
 The Laboratorio para la Ciudad issued digital certificates to participants of a week-long workshop in Mexico City in September 2016. [Check out the certificates here.](http://certs.labcd.mx/)
 
+[//]: # "start_docker_instructions"
 
 Quick Start
 -----------
@@ -21,7 +22,7 @@ Quick Start
 
 1. [Install Docker Engine and Docker Compose](https://docs.docker.com/engine/installation)
     - If you are using Mac OSX or Windows, your installation includes both Engine and Compose, so you can skip to the #installation anchor for your OS.
-        - Mac OSX: [https://docs.docker.com/engine/installation/mac/#installation](https://docs.docker.com/engine/installation/mac/#installatio)
+        - Mac OSX: [https://docs.docker.com/engine/installation/mac/#installation](https://docs.docker.com/engine/installation/mac/#installation)
         - Windows: [https://docs.docker.com/engine/installation/windows/#installation](https://docs.docker.com/engine/installation/windows/#installation)
     - If you already have Docker installed, ensure your version is >= 1.10.0, and that you have both Engine and Compose
  
@@ -61,6 +62,13 @@ The quick start steps do the following:
 2. Seeds the MongoDB database with sample fake certificates. This data is located in the mongo-seed folder
 3. Starts the container. This configuration exposes port 5000.
 
+### Limitations/Warnings
+
+- The quick start configuration is for demo purposes and not intended for production release. See [installation](installation.md).
+- As of now, the mongo instance is populated with 2 unverified certificates; they are linked to on the main page. Click
+'Verify' to see details on how verification can fail.
+
+[//]: # "end_docker_instructions"
 
 Project Documentation
 ---------------------

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,18 +1,20 @@
-Quick Start
-===========
 
-Steps
------
+Quick Start
+-----------
+
+### Steps
 
 1. [Install Docker Engine and Docker Compose](https://docs.docker.com/engine/installation)
     - If you are using Mac OSX or Windows, your installation includes both Engine and Compose, so you can skip to the #installation anchor for your OS.
-        - Mac OSX: [https://docs.docker.com/engine/installation/mac/#installation](https://docs.docker.com/engine/installation/mac/#installatio)
+        - Mac OSX: [https://docs.docker.com/engine/installation/mac/#installation](https://docs.docker.com/engine/installation/mac/#installation)
         - Windows: [https://docs.docker.com/engine/installation/windows/#installation](https://docs.docker.com/engine/installation/windows/#installation)
     - If you already have Docker installed, ensure your version is >= 1.10.0, and that you have both Engine and Compose
-
+ 
 2. Git clone the repository
 
-    `git clone https://github.com/digital-certificates/cert-viewer.git`
+    ```
+    git clone https://github.com/digital-certificates/cert-viewer.git
+    ```
 
 3. Determine your docker machine ip, which you'll use to access the webapp
 
@@ -37,17 +39,15 @@ Steps
 6. Access cert-viewer pre-populated with test data at `http://<hostname>:5000`, where hostname is given by step 3.
 
 
-About Docker Setup
-------------------
+### About Docker Setup
 The quick start steps do the following:
 
 1. Creates a container that runs the cert-viewer Flask app with MongoDB using Docker Compose [details](http://containertutorials.com/docker-compose/flask-mongo-compose.html)
 2. Seeds the MongoDB database with sample fake certificates. This data is located in the mongo-seed folder
 3. Starts the container. This configuration exposes port 5000.
 
+### Limitations/Warnings
 
-Limitations/Warnings
---------------------
 - The quick start configuration is for demo purposes and not intended for production release. See [installation](installation.md).
 - As of now, the mongo instance is populated with 2 unverified certificates; they are linked to on the main page. Click
 'Verify' to see details on how verification can fail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,11 @@ to allow learners to request a certificate and generate their own Bitcoin identi
 Getting started
 ---------------
 
-- [Quick start](quick_start.md)
+- [Quick start](docker.md)
 - [Installation](installation.md)
 - [Configuration](configuration.md)
 - [Testing](testing.md)
+- [Pre-commit hooks for developers](precommit.md)
 
 
 Data format

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -1,0 +1,14 @@
+
+Pre-commit hooks
+================
+Install the pre-commit hook as follows:
+
+```shell
+cp pre-commit.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+This does the following:
+
+- runs unit tests
+- copies docker instructions to docs/ folder (to avoid maintaining these separately)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,10 +2,11 @@ site_name: cert-viewer
 
 pages:
 - Home: index.md
-- Quick Start: quick_start.md
+- Quick Start: docker.md
 - Installation: installation.md
 - Configuration: configuration.md
 - Testing: testing.md
+- Pre-commit hooks: precommit.md
 - Certificate Format: CERTIFICATE.md
 - Database Collections: database_collections.md
 - Verify a Certificate: verify.md

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "running pre-commit hook..."
+
+# run tests with staged changes. Fail if tests fail
+git stash -q --keep-index
+./run_tests.sh
+RESULT=$?
+git stash pop -q
+[ $RESULT -ne 0 ] && exit 1
+
+# slurp in docker / quick start steps, which are reused in README.md and docs
+echo "copying docker instructions to docs/ dir"
+docker=`awk '/\start_docker_instructions"/{f=1;next}/\end_docker_instructions/{f=0}f' README.md`
+echo "$docker" | tee docs/docker.md >> /dev/null
+echo "finished running pre-commit hook"
+
+exit 0


### PR DESCRIPTION
The docker / quick start steps were duplicated between README.md and docs/quick-start.md. Keeping these in sync is error prone. See #26 

Added comment markers around the relevant parts of README.md, added a pre-commit hook to slurp in those instructions to copy to docs/docker.md.

Also added unit tests to pre-commit hook.